### PR TITLE
Fixed examples for linux.

### DIFF
--- a/Resources/Code/Programming-code/Chapter18/std_lib_facilities.h
+++ b/Resources/Code/Programming-code/Chapter18/std_lib_facilities.h
@@ -12,6 +12,10 @@
 #include <vector>
 #include <string>
 
+#ifdef linux
+#include <cstring>
+#endif
+
 using namespace std;
 
 //------------------------------------------------------------------------------

--- a/Resources/Code/Programming-code/Chapter24/chapter.24.2.1.cpp
+++ b/Resources/Code/Programming-code/Chapter24/chapter.24.2.1.cpp
@@ -7,6 +7,10 @@
 #include <iostream>
 #include <limits>
 
+#ifdef linux
+#include <climits>
+#endif
+
 using namespace std;
 
 //------------------------------------------------------------------------------

--- a/Resources/Code/Programming-code/Chapter26/chapter.26.6.cpp
+++ b/Resources/Code/Programming-code/Chapter26/chapter.26.6.cpp
@@ -6,6 +6,10 @@
 
 #include <vector>
 
+#ifdef linux
+#include <cstring>
+#endif
+
 using namespace std;
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Fixed ALL_BUILD target in linux, by adding ifdef headers in specific examples.